### PR TITLE
Get rid of `can't modify frozen String: ""` error for Ruby 2.7 upgrade

### DIFF
--- a/lib/rubycas-server-core/util.rb
+++ b/lib/rubycas-server-core/util.rb
@@ -19,7 +19,7 @@ module RubyCAS::Server::Core
     def clean_service_url(dirty_url)
       return '' if dirty_url.blank?
       parsed = URI.parse(dirty_url)
-      query = parsed.query.to_s # we really only care about the query portion of the url
+      query = parsed.query.to_s.dup # we really only care about the query portion of the url
       query.gsub!(PARAM_REGEX, '')
       query.gsub!(/[\/\?&]$/, '')
       query.gsub!(/&&/, '&')


### PR DESCRIPTION
Ruby 2.7's `to_s` returns a frozen string. Can't run `gsub!` to do in place substitution on those froze strings.